### PR TITLE
Color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,15 @@ Let's see the options of each section.
 
 * __scores__:
 
-  Default: `[17, 26, 40, 50]` (Array)
+  Default: `[14, 26, 40, 50]` (Array)
 
-  The scores used to determine what progressClass and verdicts to display.
+  The scores used to determine what verdicts to display.
+
+* __colors__:
+
+  Default: `[26, 50]` (Array)
+
+  The scores used to determine what progressClass to display.
 
 #### Example of an options object
 

--- a/examples/pwstrength.js
+++ b/examples/pwstrength.js
@@ -249,6 +249,7 @@ defaultOptions.ui.viewports = {
     errors: undefined
 };
 defaultOptions.ui.scores = [14, 26, 38, 50];
+defaultOptions.ui.colors = [26, 50];
 
 // Source: src/ui.js
 
@@ -462,23 +463,25 @@ var ui = {};
         var cssClass, barPercentage, verdictText;
 
         if (score <= 0) {
-            cssClass = 0;
             verdictText = "";
         } else if (score < options.ui.scores[0]) {
-            cssClass = 0;
             verdictText = options.ui.verdicts[0];
         } else if (score < options.ui.scores[1]) {
-            cssClass = 0;
             verdictText = options.ui.verdicts[1];
         } else if (score < options.ui.scores[2]) {
-            cssClass = 1;
             verdictText = options.ui.verdicts[2];
         } else if (score < options.ui.scores[3]) {
-            cssClass = 1;
             verdictText = options.ui.verdicts[3];
         } else {
-            cssClass = 2;
             verdictText = options.ui.verdicts[4];
+        }
+
+        if (score < options.ui.colors[0]) {
+            cssClass = 0;
+        } else if (score < options.ui.colors[1]) {
+            cssClass = 1;
+        } else {
+            cssClass = 2;
         }
 
         if (options.ui.showProgressBar) {

--- a/src/options.js
+++ b/src/options.js
@@ -86,3 +86,4 @@ defaultOptions.ui.viewports = {
     errors: undefined
 };
 defaultOptions.ui.scores = [14, 26, 38, 50];
+defaultOptions.ui.colors = [26, 50];

--- a/src/ui.js
+++ b/src/ui.js
@@ -216,23 +216,25 @@ var ui = {};
         var cssClass, barPercentage, verdictText;
 
         if (score <= 0) {
-            cssClass = 0;
             verdictText = "";
         } else if (score < options.ui.scores[0]) {
-            cssClass = 0;
             verdictText = options.ui.verdicts[0];
         } else if (score < options.ui.scores[1]) {
-            cssClass = 0;
             verdictText = options.ui.verdicts[1];
         } else if (score < options.ui.scores[2]) {
-            cssClass = 1;
             verdictText = options.ui.verdicts[2];
         } else if (score < options.ui.scores[3]) {
-            cssClass = 1;
             verdictText = options.ui.verdicts[3];
         } else {
-            cssClass = 2;
             verdictText = options.ui.verdicts[4];
+        }
+
+        if (score < options.ui.colors[0]) {
+            cssClass = 0;
+        } else if (score < options.ui.colors[1]) {
+            cssClass = 1;
+        } else {
+            cssClass = 2;
         }
 
         if (options.ui.showProgressBar) {


### PR DESCRIPTION
This adds ability to set scores to set appropriate progressClass. Previously it was hard coded and depended only on scores for verdicts. It makes more sense for the user to set thresholds to display appropriate bar color earlier or later ex. for default bootstrap colors green bar for "strong" ones and stronger and not only for "very strong" passwords.

Minor fix in `scores` default in readme, as manual contained wrong values.
